### PR TITLE
set view directory

### DIFF
--- a/lib/review.js
+++ b/lib/review.js
@@ -11,6 +11,7 @@ function review () {
   var app = express()
   
   app.set('view engine', 'jade')
+  app.set('views', __dirname + '/../views')
   app.use(express.static(__dirname + '/../public'))
   
   /**


### PR DESCRIPTION
Without this explicit setting of the view directory the render process breaks for me with:
 `Error: Failed to lookup view "index" at Function.app.render`
